### PR TITLE
Prevent "octal literals are not allowed in strict mode" error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function(clear) {
   if (clear !== false) {
-    process.stdout.write('\033[2J');
+    process.stdout.write('\x1b[2J');
   }
-  process.stdout.write('\033[0f');
+  process.stdout.write('\x1b[0f');
 };


### PR DESCRIPTION
To prevent "octal literals are not allowed in strict mode" error, I replaced octal "\033" with hex "\x1b".