### PR TITLE
keep *all* the history after full clear

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,12 @@
-var assert = require('assert');
-
-module.exports = function clear(opts) {
-    if (typeof (opts) === 'boolean') {
-        opts = {
-            fullClear: opts
-        };
+module.exports = function clear(fullClear = true, keepLastScreen = false) {
+    if (typeof fullClear == 'object') throw new Error('API has changed.');
+    if (fullClear) {
+        if (keepLastScreen) {
+            process.stdout.write('\n'.repeat(process.stdout.rows));
+        }
+        process.stdout.write('\x1b[2J\x1b[0f');
     }
-
-    opts = opts || {};
-    assert(typeof (opts) === 'object', 'opts must be an object');
-
-    opts.fullClear = opts.hasOwnProperty('fullClear') ?
-        opts.fullClear : true;
-
-    assert(typeof (opts.fullClear) === 'boolean',
-        'opts.fullClear must be a boolean');
-
-    if (opts.fullClear === true) {
-        process.stdout.write('\n'.repeat(process.stdout.rows) + '\x1b[2J');
+    else {
+        process.stdout.write('\x1b[0f');
     }
-
-    process.stdout.write('\x1b[0f');
 };

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function clear(opts) {
         'opts.fullClear must be a boolean');
 
     if (opts.fullClear === true) {
-        process.stdout.write('\x1b[2J');
+        process.stdout.write('\n'.repeat(process.stdout.rows) + '\x1b[2J');
     }
 
     process.stdout.write('\x1b[0f');


### PR DESCRIPTION
```bash
echo dont clear me; node -e "require('./')()"
```
should preserve the line `dont clear me` in the terminal history

edit: should be an extra option, sometimes its desired to keep no history

edit: added the option `keepLastScreen`

```bash
echo dont clear me; node -e "require('./')(1, 1)"
```
will keep "all the history" = history + last screen
